### PR TITLE
Add Rust to the list of supported languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@ The current supported languages are:
   * Go
   * Haskell
   * OCaml
+  * Rust

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,8 +1,6 @@
 ## rzpipe.rs
 
 The Rust Crate to interact with rizin.
-Please check [Documentation](https://radare.github.io/r2pipe.rs) to get
-started.
 
 ## License
 


### PR DESCRIPTION
### TODO
- [x] Add Rust to the list of supported languages
- [x] The [link](https://github.com/rizinorg/rz-pipe/blob/master/rust/README.md#rzpipers) on the Rust crate's README still points to [radare2's](https://radare.github.io/r2pipe.rs) documentation. Decide on what to do with that.  