### PR TITLE
move repeated code outside if statement

### DIFF
--- a/python/rzpipe/open_base.py
+++ b/python/rzpipe/open_base.py
@@ -139,13 +139,12 @@ class OpenBase(object):
                     elif (windll.kernel32.WaitNamedPipeW(pipe_name, 20000)) == 0:
                         raise OSError("Invalid Handle Value: Pipe busy")
                 self.pipe = [pipe_handle, pipe_handle]
-                self._cmd = self._cmd_pipe
             else:
                 self.pipe = [
                     int(os.environ["RZ_PIPE_IN"]),
                     int(os.environ["RZ_PIPE_OUT"]),
                 ]
-                self._cmd = self._cmd_pipe
+            self._cmd = self._cmd_pipe
             self.url = "#!pipe"
             return
         except Exception:


### PR DESCRIPTION
Hi everyone!

I just notice that the code could do some refactoring to move `self._cmd = self._cmd_pipe` outside the if statement in file `rzpipe/open_base.py`.

Thank you in advance and keep up the great work guys :P