### PR TITLE
Go: fixed pipe name, updated example

### DIFF
--- a/go/example/example.go
+++ b/go/example/example.go
@@ -3,28 +3,44 @@
 package main
 
 import (
+	"os"
 	"fmt"
-
-	".."
+	"github.com/rizinorg/rz-pipe/go"
 )
 
-func main() {
-	rzp, err := rzpipe.NewPipe("/bin/ls")
-	if err != nil {
-		print("ERROR: ", err)
+func isInRizin() (bool){
+	rzpipeIn := os.Getenv("RZ_PIPE_IN")
+	rzpipeOut := os.Getenv("RZ_PIPE_OUT")
 
-		return
+
+	if rzpipeIn == "" || rzpipeOut == "" {
+		return false
 	}
 
-	disasm, err := rzp.Cmd("pd 20")
-	if err != nil {
-		print("ERROR: ", err)
-	} else {
-		print(disasm, "\n")
-	}
-
-	err = rzp.Close()
-	if err != nil {
-		panic(fmt.Sprintf("Error closing rzpipe: %s", err))
-	}
+	return true
 }
+
+func main() {
+	path := "/bin/ls"
+	if isInRizin() {
+		path = ""
+	}
+
+	r2p, err := rzpipe.NewPipe(path)
+	if err != nil {
+		panic(err)
+	}
+	defer r2p.Close()
+
+	_, err = r2p.Cmd("aaaa")
+	if err != nil {
+		panic(err)
+	}
+	buf, err := r2p.Cmd("pi 10")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(buf)
+	fmt.Println("done")
+}
+

--- a/go/example/example.go
+++ b/go/example/example.go
@@ -26,17 +26,17 @@ func main() {
 		path = ""
 	}
 
-	r2p, err := rzpipe.NewPipe(path)
+	rzp, err := rzpipe.NewPipe(path)
 	if err != nil {
 		panic(err)
 	}
-	defer r2p.Close()
+	defer rzp.Close()
 
-	_, err = r2p.Cmd("aaaa")
+	_, err = rzp.Cmd("aaaa")
 	if err != nil {
 		panic(err)
 	}
-	buf, err := r2p.Cmd("pi 10")
+	buf, err := rzp.Cmd("pi 10")
 	if err != nil {
 		panic(err)
 	}

--- a/go/rzpipe.go
+++ b/go/rzpipe.go
@@ -1,34 +1,3 @@
-// rizin - LGPL - Copyright 2015 - nibble
-
-/*
-Package rzpipe allows to call rizin commands from Go. A simple hello world would
-look like the following snippet:
-
-	package main
-
-	import (
-		"fmt"
-		"github.com/rizin/rz-pipe-go"
-	)
-
-	func main() {
-		rzp, err := rzpipe.NewPipe("malloc://256")
-		if err != nil {
-			panic(err)
-		}
-		defer rzp.Close()
-
-		_, err = rzp.Cmd("w Hello World")
-		if err != nil {
-			panic(err)
-		}
-		buf, err := rzp.Cmd("ps")
-		if err != nil {
-			panic(err)
-		}
-		fmt.Println(buf)
-	}
-*/
 package rzpipe
 
 import (
@@ -73,11 +42,11 @@ func NewPipe(file string) (*Pipe, error) {
 }
 
 func newPipeFd() (*Pipe, error) {
-	rzpipeIn := os.Getenv("RZPIPE_IN")
-	rzpipeOut := os.Getenv("RZPIPE_OUT")
+	rzpipeIn := os.Getenv("RZ_PIPE_IN")
+	rzpipeOut := os.Getenv("RZ_PIPE_OUT")
 
 	if rzpipeIn == "" || rzpipeOut == "" {
-		return nil, fmt.Errorf("missing RZPIPE_{IN,OUT} vars")
+		return nil, fmt.Errorf("missing RZ_PIPE_{IN,OUT} vars")
 	}
 
 	rzpipeInFd, err := strconv.Atoi(rzpipeIn)
@@ -90,8 +59,8 @@ func newPipeFd() (*Pipe, error) {
 		return nil, fmt.Errorf("failed to convert OUT into file descriptor")
 	}
 
-	stdout := os.NewFile(uintptr(rzpipeInFd), "RZPIPE_IN")
-	stdin := os.NewFile(uintptr(rzpipeOutFd), "RZPIPE_OUT")
+	stdout := os.NewFile(uintptr(rzpipeInFd), "RZ_PIPE_IN")
+	stdin := os.NewFile(uintptr(rzpipeOutFd), "RZ_PIPE_OUT")
 
 	rzp := &Pipe{
 		File:   "",


### PR DESCRIPTION
The in/out pipe for golang was incorrect; also updated the example to make it work out of the box.