### PR TITLE
Fix #28 - Bad field name

### DIFF
--- a/python/rzpipe/__init__.py
+++ b/python/rzpipe/__init__.py
@@ -32,7 +32,7 @@ try:
 except ImportError:
     rzlang = None
 
-VERSION = "0.1.0"
+VERSION = "0.1.1"
 
 from .open_sync import open
 from shutil import which

--- a/python/rzpipe/open_base.py
+++ b/python/rzpipe/open_base.py
@@ -46,7 +46,8 @@ def jo2po(jo):
     from collections import namedtuple
 
     def _json_object_hook(d):
-        return namedtuple("X", d.keys(), rename=True)(*d.values())
+        keys = [x.replace('.', '_') if x != 'class' else 'bin_class' for x in d.keys()]
+        return namedtuple("X", keys)(*d.values())
 
     def json2obj(data):
         return json.loads(data, object_hook=_json_object_hook)

--- a/python/rzpipe/open_base.py
+++ b/python/rzpipe/open_base.py
@@ -46,7 +46,7 @@ def jo2po(jo):
     from collections import namedtuple
 
     def _json_object_hook(d):
-        keys = [x.replace('.', '_') if x != 'class' else 'bin_class' for x in d.keys()]
+        keys = [x.replace('.', '_') if x != 'class' else 'klass' for x in d.keys()]
         return namedtuple("X", keys)(*d.values())
 
     def json2obj(data):


### PR DESCRIPTION
This Patch fixes issue #28 

the issue was related 2 values: `class` and `cmp.csum`.
The first one is a keyword for python so i have replaced it with `klass`
The second one, was due the `.` being in the name, so i have replaced it `_`

output
```
X(arch='x86', baddr=4194304, binsz=651424, bintype='pe', bits=32, retguard=False, klass='PE32', cmp_csum='0x000a52d4', compiled='Mon Apr 24 22:38:08 2017 UTC+1', dbg_file='C:\\Builds\\13810\\Tools\\ProcDump_master\\bin\\Win32\\Release\\procdump.pdb', endian='LE', hdr_csum='0x000a52d4', guid='35DC14947AF44564BC0C59336A3D8F741', laddr=0, lang='c', machine='i386', maxopsz=16, minopsz=1, os='windows', overlay=True, cc='cdecl', pcalign=0, signed=True, subsys='Windows CUI', stripped=False, crypto=False, havecode=True, va=True, sanitiz=False, static=False, linenum=False, lsyms=False, canary=False, PIE=True, RELROCS=False, NX=True)
```