### PR TITLE
Handle empty output from json commands

### DIFF
--- a/python/rzpipe/open_base.py
+++ b/python/rzpipe/open_base.py
@@ -254,6 +254,12 @@ class OpenBase(object):
             Returns a JSON object respresenting the parsed JSON
         """
         result = self.cmd(cmd, **kwargs)
+        if result is None:
+            return None
+
+        result = result.strip()
+        if result == "":
+            return None
 
         try:
             data = json.loads(result)
@@ -270,6 +276,13 @@ class OpenBase(object):
             Returns a Python object respresenting the parsed JSON
         """
         result = self.cmd(cmd, **kwargs)
+        if result is None:
+            return None
+
+        result = result.strip()
+        if result == "":
+            return None
+
         try:
             return jo2po(result)
         except (ValueError, KeyError, TypeError) as e:


### PR DESCRIPTION
Fixes https://github.com/rizinorg/rz-pipe/issues/31#issuecomment-945562491

When the command return nothing e.g. `'\n'` the json loader complains about it. Let's just return None in those cases. That means that rizin was not able to give back any information, which is different from `[]`, that means that the information are there but there are none.