### PR TITLE
Windows cmd: Convert `\r\n` to `\n`

### DIFF
--- a/python/rzpipe/open_base.py
+++ b/python/rzpipe/open_base.py
@@ -243,6 +243,8 @@ class OpenBase(object):
 
         res = self._cmd(cmd, **kwargs)
         if res is not None:
+            if os.name == "nt":
+                res = res.replace("\r\n", "\n")
             return res
         return None
 


### PR DESCRIPTION
This pr makes the `cmd()` method convert `\r\n` to `\n` on Windows so that callers don't need to deal with the '`\r`'s.