### PR TITLE
Python: Add timeout option to open() to kill time-consuming cmd() calls

### DIFF
--- a/python/rzpipe/__init__.py
+++ b/python/rzpipe/__init__.py
@@ -32,7 +32,7 @@ try:
 except ImportError:
     rzlang = None
 
-VERSION = "0.4.0"
+VERSION = "0.5.0"
 
 from .open_sync import open
 from shutil import which

--- a/python/rzpipe/open_async.py
+++ b/python/rzpipe/open_async.py
@@ -31,8 +31,8 @@ class open(OpenBase, ContextDecorator):
         if not self._loop.is_closed():
             self._loop.close()
 
-    def __init__(self, filename="", flags=None, rz_home=None):
-        super(open, self).__init__(filename, flags)
+    def __init__(self, filename="", flags=None, rz_home=None, **kwargs):
+        super(open, self).__init__(filename, flags, **kwargs)
 
         if flags is None:
             flags = []

--- a/python/rzpipe/open_sync.py
+++ b/python/rzpipe/open_sync.py
@@ -23,8 +23,8 @@ except ImportError:
 
 
 class open(OpenBase):
-    def __init__(self, filename="", flags=None, rizin_home=None):
-        super(open, self).__init__(filename, flags)
+    def __init__(self, filename="", flags=None, rizin_home=None, **kwargs):
+        super(open, self).__init__(filename, flags, **kwargs)
         if flags is None:
             flags = []
         if filename.startswith("http://"):


### PR DESCRIPTION
Proposed changes to fix https://github.com/rizinorg/rz-pipe/issues/46

Usage:

```
import rzpipe

pipe = rzpipe.open("/bin/ls", cmd_timeout=10)
pipe.cmd('aa')
pipe.quit()
```

When the timeout is triggered it will throw an exception:

```
TimeoutError: Timeout of 10 seconds reached on 'rzpipe.cmd: aa'
```

By default, it won't enable timeout to be backward compatible